### PR TITLE
Update list to include SS4 modules and modules in CWP 2.0 recipes

### DIFF
--- a/main.css
+++ b/main.css
@@ -13,10 +13,8 @@ a {
 
 table {
     border-collapse: collapse;
-}
-
-th {
-    font-weight: normal;
+    width: 100%;
+    cellpadding: 1;
 }
 
 th, td {

--- a/main.js
+++ b/main.js
@@ -1,39 +1,3 @@
-/*
-<?php foreach ($modules as $module): ?>
-    <tr>
-        <td>
-            <?php if ($module["github"]): ?>
-                <a href="https://github.com/<?php echo $module["github"]; ?>"><?php echo $module["composer"]; ?></a>
-            <?php elseif ($module["gitlab"]): ?>
-                <a href="https://gitlab.cwp.govt.nz/<?php echo $module["gitlab"]; ?>"><?php echo $module["composer"]; ?></a>
-            <?php else: ?>
-                <?php echo $module["composer"]; ?>
-            <?php endif; ?>
-        </td>
-        <td><?php echo $module["type"]; ?></td>
-        <?php if ($module["github"]): ?>
-            <td class="progress first">
-                <a href="https://travis-ci.org/<?php echo $module["github"]; ?>">
-                    <img src="http://img.shields.io/travis/<?php echo $module["github"]; ?>.svg?style=flat-square" />
-                </a>
-            </td>
-            <td class="progress">
-                <img src="http://img.shields.io/scrutinizer/coverage/g/<?php echo $module["github"]; ?>.svg?style=flat-square" />
-            </td>
-            <td class="progress last">
-                <a href="https://scrutinizer-ci.com/g/<?php echo $module["github"]; ?>">
-                    <img src="http://img.shields.io/scrutinizer/g/<?php echo $module["github"]; ?>.svg?style=flat-square" />
-                </a>
-            </td>
-        <?php else: ?>
-            <td colspan="3">
-                Gitlab
-            </td>
-        <?php endif; ?>
-    </tr>
-<?php endforeach; ?>
-*/
-
 $.ajax({
     "url": "modules.json",
     "dataType": "json"
@@ -43,25 +7,38 @@ $.ajax({
     modules.forEach(function(module) {
         var row = "<tr>";
 
-        if (module.github) {
-            row += "<td><a href='https://github.com/" + module.github + "'>" + module.composer + "</a></td>";
-        } else if (module.gitlab) {
-            row += "<td><a href='https://gitlab.cwp.govt.nz/" + module.gitlab + "'>" + module.composer + "</a></td>";
+        if (module.addons) {
+						row += "<td><a href='https://addons.silverstripe.org/add-ons/" + module.composer + "'>" + module.composer + "</a></td>";
+				}
+        else {
+						if (module.github) {
+								row += "<td><a href='https://github.com/" + module.github + "'>" + module.composer + "</a></td>";
+						} else if (module.gitlab) {
+								row += "<td><a href='https://gitlab.cwp.govt.nz/" + module.gitlab + "'>" + module.composer + "</a></td>";
+						} else {
+								row += "<td>" + module.composer + "</td>";
+						}
+				}
+
+        if(module.type === "supported-module") {
+            row += "<td>" + "Supported module" + "</td>";
         } else {
-            row += "<td>" + module.composer + "</td>";
+            row += "<td>" + "Supported dependency" + "</td>";
         }
 
-        row += "<td>" + module.type + "</td>";
-
-        if (module.github) {
-            row += "<td class='progress first'><a href='https://travis-ci.org/" + module.github + "'><img src='http://img.shields.io/travis/" + module.github + ".svg?style=flat-square' /></a></td>";
-            row += "<td class='progress'><img src='http://img.shields.io/scrutinizer/coverage/g/" + module.github + ".svg?style=flat-square' /></td>";
-            row += "<td class='progress last'><a href='https://scrutinizer-ci.com/g/" + module.github + "'><img src='http://img.shields.io/scrutinizer/g/" + module.github + ".svg?style=flat-square' /></a></td>";
-        } else if (module.gitlab) {
-            row += "<td colspan='3'>Module on Gitlab</td>";
-        } else {
-            row += "<td colspan='3'>Module definition incomplete</td>";
-        }
+				if (module.github) {
+						row += "<td class='progress first'><a href='https://travis-ci.org/" + module.github + "'><img src='https://api.travis-ci.org/" + module.github + ".svg' /></a></td>";
+						row += "<td class='progress'><a href='https://codecov.io/gh/" + module.github + "'><img title='' src='https://codecov.io/gh/" + module.github + "/branch/master/graph/badge.svg' alt=''/></a></td>";
+						if (module.scrutinizer) {
+								row += "<td class='progress last'><a href='https://scrutinizer-ci.com/g/" + module.github + "'><img src='https://scrutinizer-ci.com/g/" + module.github + "/badges/quality-score.png'/></a></td>";
+						} else {
+								row += "<td class='progress last'><img src='https://img.shields.io/badge/Scrutinizer-n%2Fa-lightgrey.svg'/></td>";
+						}
+				} else if (module.gitlab) {
+						row += "<td colspan='3'>Module on Gitlab</td>";
+				} else {
+						row += "<td colspan='3'>Module definition incomplete</td>";
+				}
 
         row += "</tr>";
 

--- a/modules.json
+++ b/modules.json
@@ -1,362 +1,931 @@
 [
     {
-        "github": "assertchris\/hash-compat",
+        "github": "bringyourownideas\/silverstripe-maintenance",
         "gitlab": null,
-        "composer": "assertchris\/hash-compat",
-        "type": "supported-dependency"
+        "composer": "bringyourownideas\/silverstripe-maintenance",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "bringyourownideas\/silverstripe-composer-update-checker",
+        "gitlab": null,
+        "composer": "bringyourownideas\/silverstripe-composer-update-checker",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "bringyourownideas\/silverstripe-composer-security-checker",
+        "gitlab": null,
+        "composer": "bringyourownideas\/silverstripe-composer-security-checker",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
     },
     {
         "github": "colymba\/GridFieldBulkEditingTools",
         "gitlab": null,
         "composer": "colymba\/gridfield-bulk-editing-tools",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-dependency"
     },
     {
         "github": "composer\/installers",
         "gitlab": null,
         "composer": "composer\/installers",
+        "scrutinizer": false,
+        "addons": false,
         "type": "supported-dependency"
     },
     {
-        "github": null,
-        "gitlab": "cwp-themes\/default",
-        "composer": "cwp-themes\/default",
+        "github": "silverstripe\/cwp-agencyextensions",
+        "gitlab": null,
+        "composer": "cwp\/agency-extensions",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "cwp\/cwp",
+        "github": "silverstripe\/cwp",
+        "gitlab": null,
         "composer": "cwp\/cwp",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "cwp\/cwp-core",
+        "github": "silverstripe\/cwp-core",
+        "gitlab": null,
         "composer": "cwp\/cwp-core",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "cwp\/cwp-recipe-basic",
+        "github": "silverstripe\/cwp-installer",
+        "gitlab": null,
+        "composer": "cwp\/cwp-installer",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-pdfexport",
+        "gitlab": null,
+        "composer": "cwp\/cwp-pdfexport",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-recipe-basic",
+        "gitlab": null,
         "composer": "cwp\/cwp-recipe-basic",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "cwp\/cwp-recipe-basic-dev",
+        "github": "silverstripe\/cwp-recipe-basic-dev",
+        "gitlab": null,
         "composer": "cwp\/cwp-recipe-basic-dev",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "cwp\/cwp-recipe-blog",
+        "github": "silverstripe\/cwp-recipe-blog",
+        "gitlab": null,
         "composer": "cwp\/cwp-recipe-blog",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
-	{
-		"github": "guzzle\/guzzle",
-		"gitlab": null,
-		"composer": "guzzle\/guzzle",
-		"type": "supported-dependency"
-	},
+    {
+        "github": "silverstripe\/cwp-recipe-cms",
+        "gitlab": null,
+        "composer": "cwp\/cwp-recipe-cms",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-recipe-core",
+        "gitlab": null,
+        "composer": "cwp\/cwp-recipe-core",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-recipe-search",
+        "gitlab": null,
+        "composer": "cwp\/cwp-recipe-search",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-search",
+        "gitlab": null,
+        "composer": "cwp\/cwp-search",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-starter-theme",
+        "gitlab": null,
+        "composer": "cwp\/starter-theme",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-watea-theme",
+        "gitlab": null,
+        "composer": "cwp\/watea-theme",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/cwp-theme-default",
+        "gitlab": null,
+        "composer": "cwp-themes\/default",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "dnadesign\/silverstripe-elemental",
+        "gitlab": null,
+        "composer": "dnadesign\/silverstripe-elemental",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "dnadesign\/silverstripe-elemental-subsites",
+        "gitlab": null,
+        "composer": "dnadesign\/silverstripe-elemental-subsites",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-dependency"
+    },
+    {
+        "github": "dnadesign\/silverstripe-elemental-userforms",
+        "gitlab": null,
+        "composer": "dnadesign\/silverstripe-elemental-userforms",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-dependency"
+    },
     {
         "github": "hafriedlander\/phockito",
         "gitlab": null,
         "composer": "hafriedlander\/phockito",
+        "scrutinizer": false,
+        "addons": false,
         "type": "supported-dependency"
     },
     {
         "github": "hafriedlander\/silverstripe-phockito",
         "gitlab": null,
         "composer": "hafriedlander\/silverstripe-phockito",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-dependency"
     },
     {
-        "github": "silverstripe-australia\/silverstripe-gridfieldextensions",
+        "github": "lekoala\/silverstripe-debugbar",
         "gitlab": null,
-        "composer": "silverstripe-australia\/gridfieldextensions",
-        "type": "supported-dependency"
-    },
-    {
-        "github": "silverstripe-ux\/sass-twitter-bootstrap",
-        "gitlab": null,
-        "composer": "silverstripe-themes\/module_bootstrap",
-        "type": "supported-dependency"
+        "composer": "lekoala\/silverstripe-debugbar",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-activedirectory",
         "gitlab": null,
         "composer": "silverstripe\/activedirectory",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": "silverstripe-australia\/advancedworkflow",
+        "github": "silverstripe\/silverstripe-admin",
         "gitlab": null,
-        "composer": "silverstripe\/advancedworkflow",
+        "composer": "silverstripe\/admin",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-akismet",
         "gitlab": null,
         "composer": "silverstripe\/akismet",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-asset-admin",
+        "gitlab": null,
+        "composer": "silverstripe\/asset-admin",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-assets",
+        "gitlab": null,
+        "composer": "silverstripe\/assets",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-auditor",
+        "gitlab": null,
+        "composer": "silverstripe\/auditor",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-behat-extension",
+        "gitlab": null,
+        "composer": "silverstripe\/behat-extension",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-dependency"
     },
     {
         "github": "silverstripe\/silverstripe-blog",
         "gitlab": null,
         "composer": "silverstripe\/blog",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": "silverstripe\/silverstripe-contentreview",
+        "github": "silverstripe\/silverstripe-campaign-admin",
         "gitlab": null,
-        "composer": "silverstripe\/contentreview",
+        "composer": "silverstripe\/campaign-admin",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-cms",
         "gitlab": null,
         "composer": "silverstripe\/cms",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/comment-notifications",
         "gitlab": null,
         "composer": "silverstripe\/comment-notifications",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-comments",
         "gitlab": null,
         "composer": "silverstripe\/comments",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-config",
+        "gitlab": null,
+        "composer": "silverstripe\/config",
+        "scrutinizer": true,
+        "addons": false,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-content-widget",
         "gitlab": null,
         "composer": "silverstripe\/content-widget",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": null,
-        "gitlab": "silverstripe\/documentconverter",
+        "github": "silverstripe\/silverstripe-contentreview",
+        "gitlab": null,
+        "composer": "silverstripe\/contentreview",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-controllerpolicy",
+        "gitlab": null,
+        "composer": "silverstripe\/controllerpolicy",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-crontask",
+        "gitlab": null,
+        "composer": "silverstripe\/crontask",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-dms",
+        "gitlab": null,
+        "composer": "silverstripe\/dms",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-dms-cart",
+        "gitlab": null,
+        "composer": "silverstripe\/dms-cart",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-documentconverter",
+        "gitlab": null,
         "composer": "silverstripe\/documentconverter",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-elemental-blocks",
+        "gitlab": null,
+        "composer": "silverstripe\/elemental-blocks",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-environmentcheck",
         "gitlab": null,
         "composer": "silverstripe\/environmentcheck",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-errorpage",
+        "gitlab": null,
+        "composer": "silverstripe\/errorpage",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/eslint-config",
+        "gitlab": null,
+        "composer": "silverstripe\/eslint-config",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-externallinks",
         "gitlab": null,
         "composer": "silverstripe\/externallinks",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-framework",
         "gitlab": null,
         "composer": "silverstripe\/framework",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-fulltextsearch",
         "gitlab": null,
         "composer": "silverstripe\/fulltextsearch",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-graphql",
+        "gitlab": null,
+        "composer": "silverstripe\/graphql",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-graphql-devtools",
+        "gitlab": null,
+        "composer": "silverstripe\/graphql-devtools",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-dependency"
+    },
+    {
+        "github": "silverstripe\/silverstripe-gridfieldqueuedexport",
+        "gitlab": null,
+        "composer": "silverstripe\/gridfieldqueuedexport",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-html5",
         "gitlab": null,
         "composer": "silverstripe\/html5",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-hybridsessions",
         "gitlab": null,
         "composer": "silverstripe\/hybridsessions",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-iframe",
         "gitlab": null,
         "composer": "silverstripe\/iframe",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-installer",
+        "gitlab": null,
+        "composer": "silverstripe\/installer",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-ldap",
+        "gitlab": null,
+        "composer": "silverstripe\/ldap",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-lumberjack",
         "gitlab": null,
         "composer": "silverstripe\/lumberjack",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-mimevalidator",
         "gitlab": null,
         "composer": "silverstripe\/mimevalidator",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": "silverstripe-australia\/silverstripe-multivaluefield",
+        "github": "silverstripe\/silverstripe-moduleratings",
         "gitlab": null,
-        "composer": "silverstripe\/multivaluefield",
-        "type": "supported-module"
+        "composer": "silverstripe\/moduleratings",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-dependency"
     },
     {
-        "github": "silverstripe\/platform-project",
+        "github": "silverstripe\/silverstripe-moduleratings-plugin",
         "gitlab": null,
-        "composer": "silverstripe\/platform-project",
-        "type": "supported-module"
+        "composer": "silverstripe\/moduleratings-plugin",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-dependency"
     },
     {
-        "github": "silverstripe-australia\/silverstripe-queuedjobs",
+        "github": "silverstripe\/silverstripe-postgresql",
         "gitlab": null,
-        "composer": "silverstripe\/queuedjobs",
+        "composer": "silverstripe\/postgresql",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-realme",
         "gitlab": null,
         "composer": "silverstripe\/realme",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+
+    {
+        "github": "silverstripe\/recipe-authoring-tools",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-authoring-tools",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-blog",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-blog",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-cms",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-cms",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-collaboration",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-collaboration",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-content-blocks",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-content-blocks",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-core",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-core",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-form-building",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-form-building",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-plugin",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-plugin",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-reporting-tools",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-reporting-tools",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/recipe-services",
+        "gitlab": null,
+        "composer": "silverstripe\/recipe-services",
+        "scrutinizer": false,
+        "addons": false,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-registry",
         "gitlab": null,
         "composer": "silverstripe\/registry",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-reports",
         "gitlab": null,
         "composer": "silverstripe\/reports",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-restfulserver",
         "gitlab": null,
         "composer": "silverstripe\/restfulserver",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-secureassets",
         "gitlab": null,
         "composer": "silverstripe\/secureassets",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-securityreport",
         "gitlab": null,
         "composer": "silverstripe\/securityreport",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-segment-field",
+        "gitlab": null,
+        "composer": "silverstripe\/segment-field",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-selectupload",
         "gitlab": null,
         "composer": "silverstripe\/selectupload",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-sharedraftcontent",
         "gitlab": null,
         "composer": "silverstripe\/sharedraftcontent",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-siteconfig",
         "gitlab": null,
         "composer": "silverstripe\/siteconfig",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-sitewidecontent-report",
         "gitlab": null,
         "composer": "silverstripe\/sitewidecontent-report",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-spamprotection",
         "gitlab": null,
         "composer": "silverstripe\/spamprotection",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-spellcheck",
         "gitlab": null,
         "composer": "silverstripe\/spellcheck",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-sqlite3",
+        "gitlab": null,
+        "composer": "silverstripe\/sqlite3",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/sspak",
+        "gitlab": null,
+        "composer": "silverstripe\/sspak",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-staticpublishqueue",
+        "gitlab": null,
+        "composer": "silverstripe\/staticpublishqueue",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-subsites",
         "gitlab": null,
         "composer": "silverstripe\/subsites",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-tagfield",
         "gitlab": null,
         "composer": "silverstripe\/tagfield",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-taxonomy",
         "gitlab": null,
         "composer": "silverstripe\/taxonomy",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-textextraction",
         "gitlab": null,
         "composer": "silverstripe\/textextraction",
-        "type": "supported-module"
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module-in"
     },
     {
         "github": "silverstripe\/silverstripe-translatable",
         "gitlab": null,
         "composer": "silverstripe\/translatable",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-upgrader",
+        "gitlab": null,
+        "composer": "silverstripe\/upgrader",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-userforms",
         "gitlab": null,
         "composer": "silverstripe\/userforms",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": "silverstripe-australia\/silverstripe-versionedfiles",
+        "github": "silverstripe\/vendor-plugin",
         "gitlab": null,
-        "composer": "silverstripe\/versionedfiles",
+        "composer": "silverstripe\/vendor-plugin",
+        "scrutinizer": true,
+        "addons": false,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-versioned",
+        "gitlab": null,
+        "composer": "silverstripe\/versioned",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe\/silverstripe-versioned-admin",
+        "gitlab": null,
+        "composer": "silverstripe\/versioned-admin",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-versionfeed",
         "gitlab": null,
         "composer": "silverstripe\/versionfeed",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
         "github": "silverstripe\/silverstripe-widgets",
         "gitlab": null,
         "composer": "silverstripe\/widgets",
+        "scrutinizer": true,
+        "addons": true,
         "type": "supported-module"
     },
     {
-        "github": "symfony\/yaml",
+        "github": "silverstripe\/webpack-config",
         "gitlab": null,
-        "composer": "symfony\/yaml",
+        "composer": "silverstripe\/webpack-config",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "silverstripe-themes\/silverstripe-simple",
+        "gitlab": null,
+        "composer": "silverstripe-themes\/simple",
+        "scrutinizer": false,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "symbiote\/silverstripe-advancedworkflow",
+        "gitlab": null,
+        "composer": "symbiote\/silverstripe-advancedworkflow",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "symbiote\/silverstripe-gridfieldextensions",
+        "gitlab": null,
+        "composer": "symbiote\/silverstripe-gridfieldextensions",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-dependency"
+    },
+    {
+        "github": "symbiote\/silverstripe-multivaluefield",
+        "gitlab": null,
+        "composer": "symbiote\/silverstripe-multivaluefield",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "symbiote\/silverstripe-queuedjobs",
+        "gitlab": null,
+        "composer": "symbiote\/silverstripe-queuedjobs",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
+    },
+    {
+        "github": "symbiote\/silverstripe-versionedfiles",
+        "gitlab": null,
+        "composer": "symbiote\/silverstripe-versionedfiles",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-module"
     },
     {
         "github": "tijsverkoyen\/akismet",
         "gitlab": null,
         "composer": "tijsverkoyen\/akismet",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-dependency"
+    },
+    {
+        "github": "tractorcow\/classproxy",
+        "gitlab": null,
+        "composer": "tractorcow\/classproxy",
+        "scrutinizer": false,
+        "addons": false,
+        "type": "supported-dependency"
+    },
+    {
+        "github": "tractorcow\/silverstripe-fluent",
+        "gitlab": null,
+        "composer": "tractorcow\/silverstripe-fluent",
+        "scrutinizer": true,
+        "addons": true,
+        "type": "supported-dependency"
+    },
+    {
+        "github": "tractorcow\/silverstripe-proxy-db",
+        "gitlab": null,
+        "composer": "tractorcow\/silverstripe-proxy-db",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-dependency"
     },
     {
         "github": "undefinedoffset\/sortablegridfield",
         "gitlab": null,
         "composer": "undefinedoffset\/sortablegridfield",
+        "scrutinizer": false,
+        "addons": true,
         "type": "supported-dependency"
     }
 ]


### PR DESCRIPTION
Also:

- introduce two new boolean attributes, scrutinizer and addons, to aid in displaying the table of modules
- delete uncommented code. 
- link to addons page, rather than GitHub
- update links of repos that moved from GitLab to GitHub.
- update references to silverstripe-australia, since renaming to symbiote
- retrieve badges directly from Scrutinizer where possible and display custom shield badge, where not possible

Fixes https://github.com/silverstripeltd/cc-issues/issues/124