### PR TITLE
Remove moduleratings and moduleratings-plugin

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -504,22 +504,6 @@
         "type": "supported-module"
     },
     {
-        "github": "silverstripe\/silverstripe-moduleratings",
-        "gitlab": null,
-        "composer": "silverstripe\/moduleratings",
-        "scrutinizer": false,
-        "addons": true,
-        "type": "supported-dependency"
-    },
-    {
-        "github": "silverstripe\/silverstripe-moduleratings-plugin",
-        "gitlab": null,
-        "composer": "silverstripe\/moduleratings-plugin",
-        "scrutinizer": false,
-        "addons": true,
-        "type": "supported-dependency"
-    },
-    {
         "github": "silverstripe\/silverstripe-postgresql",
         "gitlab": null,
         "composer": "silverstripe\/postgresql",


### PR DESCRIPTION
The above are only required by addons and not dependencies of any other supported modules. Thus, they should not be on this list.