### PR TITLE
Fixed Github repo for fluent

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -905,7 +905,7 @@
     "type": "supported-dependency"
   },
   {
-    "github": "tractorcow\/silverstripe-fluent",
+    "github": "tractorcow-farm\/silverstripe-fluent",
     "gitlab": null,
     "composer": "tractorcow\/silverstripe-fluent",
     "scrutinizer": true,


### PR DESCRIPTION
The original repo has been "deprecated", and forked: https://github.com/tractorcow/silverstripe-fluent.
Which is super annoying: https://github.com/tractorcow-farm/silverstripe-fluent/issues/540