### PR TITLE
BUG remove depreciated repo

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -368,14 +368,6 @@
     "type": "supported-module"
   },
   {
-    "github": "silverstripe\/silverstripe-elemental-blocks",
-    "gitlab": null,
-    "composer": "silverstripe\/elemental-blocks",
-    "scrutinizer": true,
-    "addons": true,
-    "type": "supported-module"
-  },
-  {
     "github": "silverstripe\/silverstripe-elemental-bannerblock",
     "gitlab": null,
     "composer": "silverstripe\/elemental-bannerblock",


### PR DESCRIPTION
`silverstripe/silverstripe-elemental-blocks` has been archived, so removing it from the commercially supported list.