### PR TITLE
MNT Add developer-docs to supported modules for elvis

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -130,6 +130,16 @@
     "isCore": false
   },
   {
+    "github": "silverstripe/developer-docs",
+    "gitlab": null,
+    "composer": "silverstripe/developer-docs",
+    "scrutinizer": false,
+    "addons": false,
+    "type": "supported-module",
+    "githubId": 510980223,
+    "isCore": true
+  },
+  {
     "github": "silverstripe/silverstripe-elemental",
     "gitlab": null,
     "composer": "dnadesign/silverstripe-elemental",


### PR DESCRIPTION
This is needed for elvis to display developer-docs.
Accidentally originally created this PR as https://github.com/creative-commoners/supported-modules/pull/2

## Parent issue
- https://github.com/silverstripe/github-issue-search-client/issues/100