### PR TITLE
ENH Add new silverstripe/gha-add-pr-to-project repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1296,6 +1296,13 @@
       }
     },
     {
+      "github": "silverstripe/gha-add-pr-to-project",
+      "githubId": 814378564,
+      "majorVersionMapping": {
+        "*": []
+      }
+    },
+    {
       "github": "silverstripe/gha-auto-tag",
       "githubId": 498115201,
       "majorVersionMapping": {


### PR DESCRIPTION
NOTE: After merging, [elvis must be redeployed](https://vercel.com/silverstripe/github-issue-search-client) to pick up the change.

## Issue
- https://github.com/silverstripe/.github/issues/155