### PR TITLE
ENH Add gha-dispatch-release repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1324,6 +1324,13 @@
       }
     },
     {
+      "github": "silverstripe/gha-dispatch-release",
+      "githubId": 835449954,
+      "majorVersionMapping": {
+        "*": []
+      }
+    },
+    {
       "github": "silverstripe/gha-gauge-release",
       "githubId": 677152725,
       "majorVersionMapping": {


### PR DESCRIPTION
Adds https://github.com/silverstripe/gha-dispatch-release

## Issue
- https://github.com/silverstripe/gha-ci/issues/137