### PR TITLE
ENH Remove gha-gauge-release

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1324,13 +1324,6 @@
       }
     },
     {
-      "github": "silverstripe/gha-gauge-release",
-      "githubId": 677152725,
-      "majorVersionMapping": {
-        "*": []
-      }
-    },
-    {
       "github": "silverstripe/gha-generate-matrix",
       "githubId": 498115149,
       "majorVersionMapping": {


### PR DESCRIPTION
Removes https://github.com/silverstripe/gha-gauge-release/

## Issue
- https://github.com/silverstripe/gha-ci/issues/137