### PR TITLE
FIX Update github reference to ex-colymba repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -38,7 +38,7 @@
       }
     },
     {
-      "github": "colymba/GridFieldBulkEditingTools",
+      "github": "silverstripe/silverstripe-gridfield-bulk-editing-tools",
       "packagist": "colymba/gridfield-bulk-editing-tools",
       "githubId": 5071848,
       "isCore": false,


### PR DESCRIPTION
This old reference was causing the rhino merge-up and builds jobs to fail.

## Issue
- https://github.com/silverstripe/.github/issues/329