### PR TITLE
ENH Add missing module.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -665,6 +665,19 @@
       }
     },
     {
+      "github": "silverstripe/silverstripe-testsession",
+      "packagist": "silverstripe/testsession",
+      "githubId": 7240841,
+      "isCore": false,
+      "lockstepped": false,
+      "type": "module",
+      "majorVersionMapping": {
+        "4": ["2"],
+        "5": ["3"],
+        "6": ["4"]
+      }
+    },
+    {
       "github": "silverstripe/recipe-authoring-tools",
       "packagist": "silverstripe/recipe-authoring-tools",
       "githubId": 120226694,


### PR DESCRIPTION
This module isn't supported in the "commercially supported" policy sense
- but we do need visibility of it and we don't want it flooding logs with deprecation warnings. Adding it here is the only way to prevent that.

## Issue

- https://github.com/silverstripe/silverstripe-config/issues/129