### PR TITLE
ENH Update references to supported major releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor/
 composer.lock
 .phpunit.result.cache
+/.ddev*/
+/.vscode/

--- a/src/MetaData.php
+++ b/src/MetaData.php
@@ -20,31 +20,27 @@ final class MetaData
      * Lowest major release line of Silverstripe CMS which is currently supported.
      * Must be updated after a major release line goes EOL.
      */
-    public const LOWEST_SUPPORTED_CMS_MAJOR = '4';
+    public const LOWEST_SUPPORTED_CMS_MAJOR = '5';
 
     /**
      * Highest major release line of Silverstripe CMS which is currently stable and supported.
      * Must be updated after a major release line gets its stable release.
      */
-    public const HIGHEST_STABLE_CMS_MAJOR = '5';
+    public const HIGHEST_STABLE_CMS_MAJOR = '6';
 
     /**
      * PHP versions which are suported for each release of Silverstripe CMS.
      * Must be updated after each Silverstripe CMS beta release.
      */
     public const PHP_VERSIONS_FOR_CMS_RELEASES = [
-        '4.9' => ['7.1', '7.2', '7.3', '7.4'],
-        '4.10' => ['7.3', '7.4', '8.0'],
-        '4.11' => ['7.4', '8.0', '8.1'],
-        '4' => ['7.4', '8.0', '8.1'],
         '5.0' => ['8.1', '8.2'],
         '5.1' => ['8.1', '8.2'],
         '5.2' => ['8.1', '8.2', '8.3'],
         '5.3' => ['8.1', '8.2', '8.3'],
         '5.4' => ['8.1', '8.2', '8.3'],
         '5' => ['8.1', '8.2', '8.3'],
-        '6' => ['8.3', '8.4'],
         '6.0' => ['8.3', '8.4'],
+        '6' => ['8.3', '8.4'],
     ];
 
     /**
@@ -56,12 +52,7 @@ final class MetaData
      *
      * Note these are actual major branches, not CMS major versions
      */
-    public const DO_NOT_MERGE_UP_FROM_MAJOR = [
-        'bringyourownideas/silverstripe-composer-update-checker' => '2',
-        'silverstripe/silverstripe-graphql' => '3',
-        'silverstripe/silverstripe-linkfield' => '3',
-        'tractorcow-farm/silverstripe-fluent' => '4',
-    ];
+    public const DO_NOT_MERGE_UP_FROM_MAJOR = [];
 
     /**
      * List of repositories that should be outright skipped for merge-up purposes.
@@ -74,8 +65,6 @@ final class MetaData
         'silverstripe/supported-modules',
         // demo.silverstripe.org on uses the master branch
         'silverstripe/demo.silverstripe.org',
-        // sortablegridfield has master branch as default branch which has dual support for CMS 4 and 5
-        'undefinedoffset/sortablegridfield',
     ];
 
     private static array $repositoryMetaData = [];

--- a/tests/BranchLogicTest.php
+++ b/tests/BranchLogicTest.php
@@ -12,6 +12,8 @@ class BranchLogicTest extends TestCase
 {
     public function provideGetCmsMajor(): array
     {
+        $highestMajor = MetaData::HIGHEST_STABLE_CMS_MAJOR;
+        $lowestMajor = MetaData::LOWEST_SUPPORTED_CMS_MAJOR;
         return [
             'empty' => [
                 'githubRepository' => 'some/module',
@@ -22,187 +24,187 @@ class BranchLogicTest extends TestCase
             ],
             'PR branch not used to find data' => [
                 'githubRepository' => 'silverstripe/silverstripe-framework',
-                'branch' => 'pulls/5/mybugfix',
+                'branch' => 'pulls/' . $highestMajor . '/mybugfix',
                 'composerJson' => null,
                 'usePhpDepAsFallback' => true,
                 'expected' => '',
             ],
             'lockstepped with matching major' => [
                 'githubRepository' => 'silverstripe/silverstripe-framework',
-                'branch' => '5',
+                'branch' => $highestMajor,
                 'composerJson' => null,
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'lockstepped with matching major, use minor branch' => [
                 'githubRepository' => 'silverstripe/silverstripe-framework',
-                'branch' => '5.2',
+                'branch' => $this->getVersionWithOffset($highestMajor,  0, '2'),
                 'composerJson' => null,
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'lockstepped with different major' => [
                 'githubRepository' => 'silverstripe/silverstripe-admin',
-                'branch' => '3',
+                'branch' => $this->getVersionWithOffset($highestMajor,  -3),
                 'composerJson' => null,
                 'usePhpDepAsFallback' => false,
-                'expected' => '6',
+                'expected' => $highestMajor,
             ],
             'non-lockstepped' => [
                 'githubRepository' => 'silverstripe/silverstripe-tagfield',
-                'branch' => '3.9',
+                'branch' => $this->getVersionWithOffset($highestMajor,  -2, '9'),
                 'composerJson' => null,
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'non-module repo' => [
                 'githubRepository' => 'silverstripe/webpack-config',
-                'branch' => '3',
+                'branch' => $this->getVersionWithOffset($highestMajor,  -3),
                 'composerJson' => null,
                 'usePhpDepAsFallback' => false,
-                'expected' => '6',
+                'expected' => $highestMajor,
             ],
             'n.x-dev constraint' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/framework' => '5.x-dev'],
+                    'require' => ['silverstripe/framework' => $this->getVersionWithOffset($highestMajor,  0, 'x-dev')],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'n.m.x-dev constraint' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/framework' => '5.0.x-dev'],
+                    'require' => ['silverstripe/framework' => $this->getVersionWithOffset($highestMajor,  0, '0.x-dev')],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             '^n constraint' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/framework' => '^5'],
+                    'require' => ['silverstripe/framework' => '^' . $highestMajor],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'x.y.z constraint' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/framework' => '5.1.2'],
+                    'require' => ['silverstripe/framework' => $this->getVersionWithOffset($highestMajor,  0, '1.2')],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'result is actual cms major, not just the dep major' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/admin' => '^2'],
+                    'require' => ['silverstripe/admin' => '^' . $this->getVersionWithOffset($highestMajor,  -3)],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'If branch matches, composerjson is ignored' => [
                 'githubRepository' => 'silverstripe/silverstripe-framework',
-                'branch' => '5.2',
+                'branch' => $this->getVersionWithOffset($highestMajor,  0, '2'),
                 'composerJson' => [
-                    'require' => ['silverstripe/admin' => '1.x-dev'],
+                    'require' => ['silverstripe/admin' => $this->getVersionWithOffset($lowestMajor,  -3, 'x-dev')],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'composerjson used even for known modules if needed' => [
                 'githubRepository' => 'silverstripe/silverstripe-framework',
                 'branch' => 'main',
                 'composerJson' => [
-                    'require' => ['silverstripe/admin' => '1.x-dev'],
+                    'require' => ['silverstripe/admin' => $this->getVersionWithOffset($lowestMajor,  -3, 'x-dev')],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '4',
+                'expected' => $lowestMajor,
             ],
             'composer plugins are valid deps' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
-                    'require' => ['silverstripe/vendor-plugin' => '^1'],
+                    'require' => ['silverstripe/vendor-plugin' => '^' . $this->getVersionWithOffset($lowestMajor,  -3)],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '4',
+                'expected' => $lowestMajor,
             ],
             'branch is ignored when we lack metadata' => [
                 'githubRepository' => 'some/module',
-                'branch' => '3',
+                'branch' => $this->getVersionWithOffset($lowestMajor,  -2),
                 'composerJson' => [
-                    'require' => ['silverstripe/framework' => '^5'],
+                    'require' => ['silverstripe/framework' => '^' . $highestMajor],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'framework takes presedence over composer plugins' => [
                 'githubRepository' => 'some/module',
                 'branch' => '3',
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/vendor-plugin' => '^1',
-                        'silverstripe/recipe-plugin' => '^1',
-                        'silverstripe/framework' => '^6'
+                        'silverstripe/vendor-plugin' => '^1' . $this->getVersionWithOffset($lowestMajor,  0),
+                        'silverstripe/recipe-plugin' => '^' . $this->getVersionWithOffset($lowestMajor,  0),
+                        'silverstripe/framework' => '^' . $highestMajor,
                     ],
                 ],
                 'usePhpDepAsFallback' => false,
-                'expected' => '6',
+                'expected' => $highestMajor,
             ],
             'PHP only used if explicitly asked for' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
                     'require' => [
-                        'php' => '^8.1',
+                        'php' => '^' . MetaData::PHP_VERSIONS_FOR_CMS_RELEASES[$highestMajor . '.0'][0],
                         'unknown/dependency' => '^1'
                     ],
                 ],
                 'usePhpDepAsFallback' => false,
                 'expected' => '',
             ],
-            'PHP matches minimum allowed cms4' => [
+            'PHP matches minimum allowed lowest major' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
                     'require' => [
-                        'php' => '^7.4',
+                        'php' => '^' . MetaData::PHP_VERSIONS_FOR_CMS_RELEASES[$lowestMajor . '.0'][0],
                         'unknown/dependency' => '^1'
                     ],
                 ],
                 'usePhpDepAsFallback' => true,
-                'expected' => '4',
+                'expected' => $lowestMajor,
             ],
-            'PHP matches minimum allowed cms5' => [
+            'PHP matches minimum allowed ihghest major' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
                     'require' => [
-                        'php' => '^8.1',
+                        'php' => '^' . MetaData::PHP_VERSIONS_FOR_CMS_RELEASES[$highestMajor . '.0'][0],
                         'unknown/dependency' => '^1'
                     ],
                 ],
                 'usePhpDepAsFallback' => true,
-                'expected' => '5',
+                'expected' => $highestMajor,
             ],
             'PHP doesnt have to be exactly the same as installer constraint' => [
                 'githubRepository' => 'some/module',
                 'branch' => 'mybranch',
                 'composerJson' => [
                     'require' => [
-                        'php' => '^8.0',
+                        'php' => '^8',
                         'unknown/dependency' => '^1'
                     ],
                 ],
                 'usePhpDepAsFallback' => true,
-                'expected' => '5',
+                'expected' => $lowestMajor,
             ],
             'tried everything, no match' => [
                 'githubRepository' => 'some/module',
@@ -238,332 +240,380 @@ class BranchLogicTest extends TestCase
         $this->assertSame($expected, $cmsMajor);
     }
 
+    private function getVersionWithOffset(string $baseMajor, int $offset, string|int $minor = ''): string
+    {
+        $version = (string)($baseMajor + $offset);
+        if ($minor !== '') {
+            $version .= ".$minor";
+        }
+        return $version;
+    }
+
     public function provideGetBranchesForMergeUp(): array
     {
+        $highestMajor = MetaData::HIGHEST_STABLE_CMS_MAJOR;
+        $lowestMajor = MetaData::LOWEST_SUPPORTED_CMS_MAJOR;
+        $highestPHPVersion = MetaData::PHP_VERSIONS_FOR_CMS_RELEASES[$highestMajor][0];
+        $lowestPHPVersion = MetaData::PHP_VERSIONS_FOR_CMS_RELEASES[array_key_first(MetaData::PHP_VERSIONS_FOR_CMS_RELEASES)][0];
         return [
             'no branches' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0-beta1',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0-beta1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/framework' => '^5.0'
+                        'silverstripe/framework' => '^' . $this->getVersionWithOffset($highestMajor, 0, '0'),
                     ]
                 ],
                 'expected' => [],
             ],
             'no tags' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1',
-                    '6'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/framework' => '^5.0'
+                        'silverstripe/framework' => '^' . $this->getVersionWithOffset($highestMajor, 0, '0'),
                     ]
                 ],
                 // Note that this would result in an exception in the merge-ups action itself.
-                'expected' => ['4.10', '4.11', '4.12', '4.13', '4', '5.0', '5.1', '5', '6'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 1),
+                ],
             ],
             '5.1.0-beta1, CMS 6 branch detected on silverstripe/framework' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0-beta1',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0-beta1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1',
-                    '6'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/framework' => '^5.0'
+                        'silverstripe/framework' => '^' . $this->getVersionWithOffset($highestMajor, 0, '0'),
                     ]
                 ],
-                'expected' => ['4.13', '4', '5.0', '5.1', '5', '6'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 1),
+                ],
             ],
             '5.1.0 stable and match on silverstripe/cms' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/cms' => '^5.1'
+                        'silverstripe/cms' => '^' . $this->getVersionWithOffset($highestMajor, 0, '1'),
                     ]
                 ],
-                'expected' => ['4.13', '4', '5.1', '5'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                ],
             ],
             'match on silverstripe/assets' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
                 ],
                 'repoBranches' => [
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/assets' => '^2.0'
+                        'silverstripe/assets' => '^' . $this->getVersionWithOffset($highestMajor, -3, '0'),
                     ]
                 ],
-                'expected' => ['4.13', '4', '5.1', '5'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                ],
             ],
             'match on silverstripe/mfa' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
                 ],
                 'repoBranches' => [
-                    '4',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/mfa' => '^5.0'
+                        'silverstripe/mfa' => '^' . $this->getVersionWithOffset($highestMajor, 0, '0'),
                     ]
                 ],
-                'expected' => ['4.13', '4', '5.1', '5'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                ],
             ],
-            'Missing `1` branch and match on php version in composer.json' => [
+            'Missing a major branch and match on php version in composer.json' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '2',
+                'defaultBranch' => $this->getVersionWithOffset($lowestMajor, -2),
                 'repoTags' => [
-                    '2.1.0-beta1',
-                    '2.0.9',
-                    '1.13.11',
-                    '1.12.11',
-                    '1.11.11',
-                    '1.10.11'
+                    $this->getVersionWithOffset($lowestMajor, -2, '1.0-beta1'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '0.9'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '13.11'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '12.11'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '11.11'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '10.11'),
                 ],
                 'repoBranches' => [
-                    '1.10',
-                    '1.11',
-                    '1.12',
-                    '1.13',
-                    '2',
-                    '2.0',
-                    '2.1'
+                    $this->getVersionWithOffset($lowestMajor, -3, '10'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '11'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '12'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '13'),
+                    $this->getVersionWithOffset($lowestMajor, -2),
+                    $this->getVersionWithOffset($lowestMajor, -2, '0'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '1'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'php' => '^8.1'
+                        'php' => '^' . $highestPHPVersion,
                     ]
                 ],
-                'expected' => ['1.13', '2.0', '2.1', '2'],
+                'expected' => [
+                    $this->getVersionWithOffset($lowestMajor, -3, '13'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '0'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '1'),
+                    $this->getVersionWithOffset($lowestMajor, -2),
+                ],
             ],
             'Two minor branches without stable tags in composer.json' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '2',
+                'defaultBranch' => $this->getVersionWithOffset($lowestMajor, -2),
                 'repoTags' => [
-                    '2.3.0-alpha1',
-                    '2.2.0-beta1',
-                    '2.1.0',
-                    '2.0.9',
-                    '1.13.11'
+                    $this->getVersionWithOffset($lowestMajor, -2, '3.0-alpha1'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '2.0-beta1'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '1.0'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '0.9'),
+                    $this->getVersionWithOffset($lowestMajor, -3, '13.11'),
                 ],
                 'repoBranches' => [
-                    '2',
-                    '2.0',
-                    '2.1',
-                    '2.2',
-                    '2.3',
-                    '1',
-                    '1.13'
+                    $this->getVersionWithOffset($lowestMajor, -2),
+                    $this->getVersionWithOffset($lowestMajor, -2, '0'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '1'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '2'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '3'),
+                    $this->getVersionWithOffset($lowestMajor, -3),
+                    $this->getVersionWithOffset($lowestMajor, -3, '13'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'php' => '^8.1'
+                        'php' => '^' . $highestPHPVersion,
                     ]
                 ],
-                'expected' => ['1.13', '1', '2.1', '2.2', '2.3', '2'],
+                'expected' => [
+                    $this->getVersionWithOffset($lowestMajor, -3, '13'),
+                    $this->getVersionWithOffset($lowestMajor, -3),
+                    $this->getVersionWithOffset($lowestMajor, -2, '1'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '2'),
+                    $this->getVersionWithOffset($lowestMajor, -2, '3'),
+                    $this->getVersionWithOffset($lowestMajor, -2),
+                ],
             ],
-            'Module where default branch has not been changed from CMS 4 and there is a new CMS 6 branch' => [
+            'Module where default branch has not been changed from previous major and there is a new major branch' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5', // this repo has a '5' branch for CMS 4 and a '6' branch for CMS 5
+                // e.g. this repo has a '5' branch for CMS 4 and a '6' branch for CMS 5
+                'defaultBranch' => $this->getVersionWithOffset($lowestMajor, 1),
                 'repoTags' => [
-                    '6.0.0',
-                    '5.9.1',
-                    '4.0.1'
+                    $this->getVersionWithOffset($lowestMajor, 2, '0.0'),
+                    $this->getVersionWithOffset($lowestMajor, 1, '9.1'),
+                    $this->getVersionWithOffset($lowestMajor, 0, '0.1'),
                 ],
                 'repoBranches' => [
-                    '7',
-                    '6',
-                    '6.0',
-                    '5',
-                    '5.9',
-                    '5.8',
-                    '5.7'
+                    $this->getVersionWithOffset($lowestMajor, 3),
+                    $this->getVersionWithOffset($lowestMajor, 2),
+                    $this->getVersionWithOffset($lowestMajor, 2, '0'),
+                    $this->getVersionWithOffset($lowestMajor, 1),
+                    $this->getVersionWithOffset($lowestMajor, 1, '9'),
+                    $this->getVersionWithOffset($lowestMajor, 1, '8'),
+                    $this->getVersionWithOffset($lowestMajor, 1, '7'),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'php' => '^7.4',
-                        'silverstripe/framework' => '^4.11'
+                        'php' => '^' . $lowestPHPVersion,
+                        'silverstripe/framework' => '^' . $this->getVersionWithOffset($lowestMajor, 0, '11'),
                     ]
                 ],
-                'expected' => ['5.9', '5', '6.0', '6', '7'],
+                'expected' => [
+                    $this->getVersionWithOffset($lowestMajor, 1, '9'),
+                    $this->getVersionWithOffset($lowestMajor, 1),
+                    $this->getVersionWithOffset($lowestMajor, 2, '0'),
+                    $this->getVersionWithOffset($lowestMajor, 2),
+                    $this->getVersionWithOffset($lowestMajor, 3),
+                ],
             ],
             'developer-docs' => [
                 'githubRepository' => 'silverstripe/developer-docs',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '4.13.0',
-                    '5.0.0'
+                    $this->getVersionWithOffset($highestMajor, -1, '13.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.0'),
                 ],
                 'repoBranches' => [
-                    '5',
-                    '5.0',
-                    '4.13',
-                    '4.12',
-                    '4',
-                    '3'
+                    $highestMajor,
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -2),
                 ],
                 'composerJson' => [
                     'no-require' => new stdClass(),
                 ],
-                'expected' => ['4.13', '4', '5.0', '5'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $highestMajor,
+                ],
             ],
             'More than 6 branches is fine' => [
                 'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '5',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.2.0-beta1',
-                    '5.1.0-beta1',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '2.0-beta1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0-beta1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1',
-                    '5.2',
-                    '6'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '2'),
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/framework' => '^5.0'
+                        'silverstripe/framework' => '^' . $this->getVersionWithOffset($highestMajor, 0),
                     ]
                 ],
-                'expected' => ['4.13', '4', '5.0', '5.1', '5.2', '5', '6'],
-            ],
-            'cwp-watea-theme' => [
-                'githubRepository' => 'lorem/ipsum',
-                'defaultBranch' => '4',
-                'repoTags' => [
-                    '4.0.0',
-                    '5.0.9',
-                    '3.2.0',
-                    '3.1.0',
-                    '3.0.0'
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '2'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
-                'repoBranches' => [
-                    '1',
-                    '1.0',
-                    '2',
-                    '2.0',
-                    '3',
-                    '3.0',
-                    '3.1',
-                    '3.2',
-                    '4',
-                    '4.0'
-                ],
-                'composerJson' => [
-                    'require' => [
-                        'cwp/starter-theme' => '^4'
-                    ]
-                ],
-                'expected' => ['3.2', '3', '4.0', '4'],
             ],
             'gha-ci' => [
                 'githubRepository' => 'silverstripe/gha-ci',
@@ -611,169 +661,72 @@ class BranchLogicTest extends TestCase
                 ],
                 'expected' => ['1.4', '1'],
             ],
-            'silverstripe-linkfield beta' => [
-                'githubRepository' => 'silverstripe/silverstripe-linkfield',
-                'defaultBranch' => '4',
-                'repoTags' => [
-                    '3.0.0-beta1',
-                    '2.0.0',
-                    '1.0.0'
-                ],
-                'repoBranches' => [
-                    '1',
-                    '2',
-                    '3',
-                    '4',
-                    '4.0',
-                    '5'
-                ],
-                'composerJson' => [
-                    'require' => [
-                        'silverstripe/framework' => '^5'
-                    ]
-                ],
-                'expected' => ['4.0', '4', '5'],
-            ],
-            'silverstripe-linkfield stable' => [
-                'githubRepository' => 'silverstripe/silverstripe-linkfield',
-                'defaultBranch' => '4',
-                'repoTags' => [
-                    '4.0.0',
-                    '3.0.0',
-                    '2.0.0',
-                    '1.0.0'
-                ],
-                'repoBranches' => [
-                    '1',
-                    '2',
-                    '3',
-                    '3.0',
-                    '3.1',
-                    '3.999',
-                    '4',
-                    '4.0',
-                    '5'
-                ],
-                'composerJson' => [
-                    'require' => [
-                        'silverstripe/framework' => '^5'
-                    ]
-                ],
-                'expected' => ['4.0', '4', '5'],
-            ],
             'Incorrect default branch for supported module' => [
                 'githubRepository' => 'silverstripe/silverstripe-cms',
                 'defaultBranch' => 'main',
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
                 ],
                 'composerJson' => null,
-                'expected' => ['4.13', '4', '5.1', '5'],
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                ],
             ],
-            'Incorrect default branch for supported module' => [
-                'githubRepository' => 'silverstripe/silverstripe-cms',
-                'defaultBranch' => 'main',
+            'Branches in the reverse order, which used to fail' => [
+                'githubRepository' => 'silverstripe/framework',
+                'defaultBranch' => $highestMajor,
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, -3, '8.6'),
+                    $this->getVersionWithOffset($highestMajor, -3, '7.4'),
+                    $this->getVersionWithOffset($highestMajor, -2, '1.21'),
+                    $this->getVersionWithOffset($highestMajor, -2, '0.4'),
+                    $this->getVersionWithOffset($highestMajor, -1, '0.5'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.1'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -3, '8'),
+                    $this->getVersionWithOffset($highestMajor, -3, '7'),
+                    $this->getVersionWithOffset($highestMajor, -3),
+                    $this->getVersionWithOffset($highestMajor, -2, '1'),
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -1, '0'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $highestMajor,
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
                 'composerJson' => null,
-                'expected' => ['4.13', '4', '5.1', '5'],
-            ],
-            'Fluent, which had weird gaps in its support' => [
-                'githubRepository' => 'tractorcow-farm/silverstripe-fluent',
-                'defaultBranch' => '7',
-                'repoTags' => [
-                    '7.0.1',
-                    '7.1.0',
-                    '6.0.5',
-                    '5.0.4',
-                    '5.1.21',
-                    '4.7.4',
-                    '4.8.6',
+                'expected' => [
+                    $this->getVersionWithOffset($highestMajor, -1, '0'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
+                    $highestMajor,
+                    $this->getVersionWithOffset($highestMajor, 1),
                 ],
-                'repoBranches' => [
-                    '8',
-                    '7',
-                    '7.0',
-                    '7.1',
-                    '6',
-                    '6.0',
-                    '5',
-                    '5.0',
-                    '5.1',
-                    '4',
-                    '4.7',
-                    '4.8',
-                ],
-                'composerJson' => null,
-                'expected' => ['6.0', '6', '7.1', '7', '8'],
-            ],
-            'Fluent with branches in the reverse order, which used to fail' => [
-                'githubRepository' => 'tractorcow-farm/silverstripe-fluent',
-                'defaultBranch' => '7',
-                'repoTags' => [
-                    '4.8.6',
-                    '4.7.4',
-                    '5.1.21',
-                    '5.0.4',
-                    '6.0.5',
-                    '7.1.0',
-                    '7.0.1',
-                ],
-                'repoBranches' => [
-                    '4.8',
-                    '4.7',
-                    '4',
-                    '5.1',
-                    '5.0',
-                    '5',
-                    '6.0',
-                    '6',
-                    '7.1',
-                    '7.0',
-                    '7',
-                    '8',
-                ],
-                'composerJson' => null,
-                'expected' => ['6.0', '6', '7.1', '7', '8'],
             ],
         ];
     }
@@ -807,37 +760,38 @@ class BranchLogicTest extends TestCase
 
     public function provideGetBranchesForMergeUpExceptions(): array
     {
+        $highestMajor = MetaData::HIGHEST_STABLE_CMS_MAJOR;
         return [
             'Incorrect default branch for random module' => [
                 'githubRepository' => 'lorem/ipsum',
                 'defaultBranch' => 'main',
                 'repoTags' => [
-                    '5.1.0',
-                    '5.0.9',
-                    '4.13.11',
-                    '4.12.11',
-                    '4.11.11',
-                    '4.10.11',
-                    '3.7.4'
+                    $this->getVersionWithOffset($highestMajor, 0, '1.0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '0.9'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11.11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '10.11'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7.4'),
                 ],
                 'repoBranches' => [
-                    '3',
-                    '3.6',
-                    '3.7',
-                    '4',
-                    '4.10',
-                    '4.11',
-                    '4.12',
-                    '4.13',
-                    '5',
-                    '5.0',
-                    '5.1'
+                    $this->getVersionWithOffset($highestMajor, -2),
+                    $this->getVersionWithOffset($highestMajor, -2, '6'),
+                    $this->getVersionWithOffset($highestMajor, -2, '7'),
+                    $this->getVersionWithOffset($highestMajor, -1),
+                    $this->getVersionWithOffset($highestMajor, -1, '10'),
+                    $this->getVersionWithOffset($highestMajor, -1, '11'),
+                    $this->getVersionWithOffset($highestMajor, -1, '12'),
+                    $this->getVersionWithOffset($highestMajor, -1, '13'),
+                    $this->getVersionWithOffset($highestMajor, 0),
+                    $this->getVersionWithOffset($highestMajor, 0, '0'),
+                    $this->getVersionWithOffset($highestMajor, 0, '1'),
                 ],
                 // Even though we know what CMS major to use, because the default branch
                 // is incorrect we can't get a good mapping for the rest of the branches
                 'composerJson' => [
                     'require' => [
-                        'silverstripe/cms' => '^5.1',
+                        'silverstripe/cms' => '^' . $this->getVersionWithOffset($highestMajor, 0, '1'),
                     ]
                 ],
             ],


### PR DESCRIPTION
NOTE: After this is merged, I will tag a new `2.0.0` and update our constraints wherever appropriate before continuing.

## Issue

- https://github.com/silverstripe/.github/issues/407