### PR TITLE
ENH Add new non-blocking-sessions module for CMS 5

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1598,6 +1598,14 @@
       }
     },
     {
+      "github": "silverstripe/silverstripe-non-blocking-sessions",
+      "packagist": "silverstripe/non-blocking-sessions",
+      "githubId": 1021093050,
+      "majorVersionMapping": {
+        "5": ["1"]
+      }
+    },
+    {
       "github": "silverstripe/doorman",
       "packagist": "asyncphp/doorman",
       "githubId": 38816427,


### PR DESCRIPTION
This isn't a supported module in the official sense, but we do want to keep track of it, so we're adding it to the list but as a misc module. This is similar to `silverstripe/silverstripe-frameworktest`

## Issue

- https://github.com/silverstripe/.github/issues/401