### PR TITLE
ENH Update isCore and lockstepped

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -132,7 +132,7 @@
       "github": "silverstripe/developer-docs",
       "packagist": "silverstripe/developer-docs",
       "githubId": 510980223,
-      "isCore": true,
+      "isCore": false,
       "lockstepped": false,
       "type": "other",
       "majorVersionMapping": {
@@ -278,8 +278,8 @@
       "github": "silverstripe/silverstripe-campaign-admin",
       "packagist": "silverstripe/campaign-admin",
       "githubId": 85750633,
-      "isCore": true,
-      "lockstepped": true,
+      "isCore": false,
+      "lockstepped": false,
       "type": "module",
       "majorVersionMapping": {
         "4": ["1"],
@@ -483,7 +483,7 @@
       "github": "silverstripe/silverstripe-graphql",
       "packagist": "silverstripe/graphql",
       "githubId": 68341446,
-      "isCore": true,
+      "isCore": false,
       "lockstepped": false,
       "type": "module",
       "majorVersionMapping": {
@@ -616,7 +616,7 @@
       "github": "silverstripe/silverstripe-mimevalidator",
       "packagist": "silverstripe/mimevalidator",
       "githubId": 22493606,
-      "isCore": false,
+      "isCore": true,
       "lockstepped": false,
       "type": "module",
       "majorVersionMapping": {
@@ -1269,7 +1269,7 @@
       "github": "silverstripe/silverstripe-login-forms",
       "packagist": "silverstripe/login-forms",
       "githubId": 155142697,
-      "isCore": false,
+      "isCore": true,
       "lockstepped": false,
       "type": "module",
       "majorVersionMapping": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/supported-modules/issues/72

Definitions for "isCore" and "lockstepped" on are this modules [readme](https://github.com/silverstripe/supported-modules?tab=readme-ov-file#format)

I've set lockstepped to false for anything that was lockstepped in CMS 5, but no longer in CMS 6, like recipe-authoring-tools.  I think it's cleaner to simply not simply not consider CMS 5, otherwise you have something like campaign-admin that was lockstepped in CMS 5, but isn't in CMS 6.

I used the following script to show what needed to be updated - you might want to double check my method of deriving lockstepped since it was very manual

```php
<?php

// Load the JSON files
$repositories_json_path = __DIR__ . '/repositories.json';
// composer.lock after running `composer create-project silverstripe/installer:^6`
$composer_lock_path = __DIR__ . '/composer-cms6.lock';
$repositories_data = json_decode(file_get_contents($repositories_json_path), true);
$composer_lock_data = json_decode(file_get_contents($composer_lock_path), true);

// Extract package names from composer-cms6.lock
$core_packages = [];
if (isset($composer_lock_data['packages'])) {
    foreach ($composer_lock_data['packages'] as $package) {
        $core_packages[$package['name']] = true;
    }
}

// List of lockstepped packages
// This was generated by looking at recipe-cms 5.4 + recipe-core for 5.4 and seeing all of the modules that ended with '.4'
// and then removing campaign-admin from the list
$lockstepped_packages = [
    "silverstripe/recipe-kitchen-sink" => true,
    "silverstripe/recipe-core" => true,
    "silverstripe/recipe-cms" => true,
    "silverstripe/installer" => true,
    "silverstripe/admin" => true,
    "silverstripe/assets" => true,
    "silverstripe/asset-admin" => true,
    "silverstripe/versioned-admin" => true,
    "silverstripe/cms" => true,
    "silverstripe/errorpage" => true,
    "silverstripe/framework" => true,
    "silverstripe/reports" => true,
    "silverstripe/siteconfig" => true,
    "silverstripe/versioned" => true,
];

function f($b) {
    return $b ? 'true' : 'false';
}

// Update repositories.json data
foreach ($repositories_data['supportedModules'] as &$repo) {
    $repo_name = $repo['packagist'];
    // Set isCore
    $is_core = f($repo['isCore']);
    $should_core = f(isset($core_packages[$repo_name]));
    if ($is_core != $should_core && $repo_name != 'silverstripe/installer') {
        echo "Update $repo_name isCore - is $is_core, should be $should_core\n";
    }
    // Set lockstepped
    $is_lockstepped = f($repo['lockstepped']);
    $should_lockstepped = f(isset($lockstepped_packages[$repo_name]));
    if ($is_lockstepped != $should_lockstepped) {
        echo "Update $repo_name isLockstepped - is $is_lockstepped, should be $should_lockstepped\n";
    }
}

```